### PR TITLE
Fix wrong version check

### DIFF
--- a/guess-style.el
+++ b/guess-style.el
@@ -88,7 +88,7 @@
     (c-basic-offset . guess-style-guess-c-basic-offset)
     (nxml-child-indent . guess-style-guess-indent)
     (css-indent-offset . guess-style-guess-indent)
-    (,(if (and (>= emacs-major-version 24) (>= emacs-minor-version 3))
+    (,(if (and (version<= "24.3" emacs-version))
           'python-indent-offset
         'python-indent) . guess-style-guess-indent))
   "*A list of cons containing a variable and a guesser function."


### PR DESCRIPTION
The version check code here is wrong, which is causing #2 to happen again on e.g. Emacs 25.1 and 26.0.